### PR TITLE
Potential fix for code scanning alert no. 42: Query built from user-controlled sources

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/sqlinjection/mitigation/Servers.java
+++ b/src/main/java/org/owasp/webgoat/lessons/sqlinjection/mitigation/Servers.java
@@ -48,13 +48,16 @@ public class Servers {
   @ResponseBody
   public List<Server> sort(@RequestParam String column) throws Exception {
     List<Server> servers = new ArrayList<>();
+    List<String> allowedColumns = List.of("id", "hostname", "ip", "mac", "status", "description");
+
+    if (!allowedColumns.contains(column)) {
+      throw new IllegalArgumentException("Invalid column name: " + column);
+    }
 
     try (var connection = dataSource.getConnection()) {
       try (var statement =
           connection.prepareStatement(
-              "select id, hostname, ip, mac, status, description from SERVERS where status <> 'out"
-                  + " of order' order by "
-                  + column)) {
+              "select id, hostname, ip, mac, status, description from SERVERS where status <> 'out of order' order by " + column)) {
         try (var rs = statement.executeQuery()) {
           while (rs.next()) {
             Server server =


### PR DESCRIPTION
Potential fix for [https://github.com/SergioCalpe/UCM_WebGoat/security/code-scanning/42](https://github.com/SergioCalpe/UCM_WebGoat/security/code-scanning/42)

To fix the problem, we need to avoid using string concatenation to build the SQL query with user-provided input. Instead, we should use a whitelist approach to validate the `column` parameter against a predefined list of allowed column names. This ensures that only valid column names are used in the query, preventing SQL injection attacks.

1. Define a list of allowed column names.
2. Validate the `column` parameter against the list of allowed column names.
3. If the `column` parameter is valid, proceed with the query using the validated column name.
4. If the `column` parameter is not valid, handle the error appropriately (e.g., return an error response).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
